### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ and exchange only these contacts, rather than sending the entire contact list fr
 The source code for this library is divided among several repositories.
 
 - [gensync-core](https://github.com/nislab/gensync-core) - the core framework code that is used by other repositories.
-- [gensync-lib-linux](https://github.com/nislab/gensync-lib) - used to produce the GenSync library and associated headers.
-- [gensync-macports](https://github.com/nislab/gensync-macports) - used to produce the [macports](https://ports.macports.org/port/gensync/details/) version of the GenSync library for MacOS.
+- [gensync-lib](https://github.com/nislab/gensync-macports) - used to produce the [macports](https://ports.macports.org/port/gensync/details/) version of the GenSync library for MacOS.
 - [gensync-benchmarking](https://github.com/nislab/gensync-benchmarking) - used for including benchmarking capabilities.
 
 ---


### PR DESCRIPTION
Get rid of the gensync-lib-linux from the ReadMe, and rename gensync-macports to gensync-lib